### PR TITLE
Fix CPIO test to not rely on file mode

### DIFF
--- a/test/util/test_cpio.py
+++ b/test/util/test_cpio.py
@@ -601,7 +601,7 @@ class TestCpio(OscTest):
         hdr = archive_reader.next_header()
         self.assertEqual(hdr.magic, '070701')
 #        self.assertEqual(hdr.ino, 1788176)
-        self.assertEqual(hdr.mode, 33188)
+        self.assertEqual(hdr.mode, st.st_mode)
         self.assertEqual(hdr.uid, st.st_uid)
         self.assertEqual(hdr.gid, st.st_gid)
         self.assertEqual(hdr.nlink, 1)


### PR DESCRIPTION
With different umask when unpacking the archive, the file can have other
mode than expected and this leads to test failure.

This fixes it to expect the same mode as the original file has.

Signed-off-by: Michal Čihař michal@cihar.com
