### PR TITLE
Fixed handling old style osc config

### DIFF
--- a/osc2/cli/cli.py
+++ b/osc2/cli/cli.py
@@ -56,6 +56,8 @@ def _init(apiurl):
             if password is None:
                 msg = "No password provided for %s" % section
                 raise ValueError(msg)
+            if '://' not in section:
+                section = 'https://{0}'.format(section)
             Osc.init(section, username=user, password=password)
             return section
 


### PR DESCRIPTION
In past, the ~/.oscrc section could use server name only without the
protocol, so let's adjust the URL according to this in osc2 as well.
