### PR TITLE
Fix listing of SRs without description

### DIFF
--- a/osc2/cli/request/request_list.jinja2
+++ b/osc2/cli/request/request_list.jinja2
@@ -30,7 +30,7 @@
 {%- endif -%}
 {% endblock history -%}
 {% block description -%}
-{% if request.description.text is not none %}
+{% if request.description and request.description.text is not none %}
         Descr: {{ request.description.text | indent(15, false) }}
 {%- endif -%}
 {% endblock description -%}


### PR DESCRIPTION
Some SRs lack description attribute and osc2 then fails to list them.
