### PR TITLE
Support for running tests in Travis CI and Coveralls

### DIFF
--- a/.travis-requirements.txt
+++ b/.travis-requirements.txt
@@ -1,0 +1,1 @@
+coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "pypy"
+env:
+  global: 
+    - PYCURL_SSL_LIBRARY=openssl
+  matrix:
+    - LXML_VERSION="<3"
+    - LXML_VERSION=""
+# Need to install pycurl separately as urlgrabber needs it at setup
+install:
+  - pip install pycurl
+  - pip install lxml$LXML_VERSION
+  - pip install -r requirements.txt
+  - pip install -r .travis-requirements.txt
+script:
+  - coverage run --source=. ./setup.py test
+after_script:
+  - coveralls
+matrix:
+  exclude:
+    - python: "pypy"
+      env: LXML_VERSION="<3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 lxml
 pycurl
 urlgrabber
+jinja2


### PR DESCRIPTION
This add configuration for Travis and Coveralls.

The tests are executed against more python versions and lxml as well.
Testsuite fails with current lxml right now.

You also need to activate repository build and coverage collection on both https://travis-ci.org/ and https://coveralls.io/