### PR TITLE
new comments framework

### DIFF
--- a/osc2/cli/cli.py
+++ b/osc2/cli/cli.py
@@ -180,6 +180,7 @@ def import_ui():
     import osc2.cli.commit.ui
     import osc2.cli.status.ui
     import osc2.cli.add.ui
+    import osc2.cli.comment.ui
 
 
 def call(func):

--- a/osc2/cli/comment/comment.py
+++ b/osc2/cli/comment/comment.py
@@ -1,0 +1,199 @@
+"""Provides controller functions for the "comment" command."""
+
+import logging
+import collections
+
+from osc2.httprequest import HTTPError
+from osc2.util.xpath import XPathBuilder
+from osc2.comments import PackageComment, ProjectComment, RequestComment
+from osc2.comments import DeleteComment
+from osc2.cli.util.env import run_pager, edit_message
+from osc2.cli.util.shell import AbstractShell, ShellSyntaxError
+
+LIST_TEMPLATE = 'comment/comment_list.jinja2'
+SHELL_TEMPLATE = 'comment/comment_shell.jinja2'
+CREATE_TEMPLATE = 'comment/comment_create.jinja2'
+
+
+def logger():
+    """Returns a logging.Logger object."""
+    return logging.getLogger(__name__)
+
+
+class CommentController(object):
+    """ Main class for the comment handling. Includes
+    methods for package, project and request comments
+
+    """
+
+    @classmethod
+    def package_comment(cls, renderer, project, package, method, info,
+                        comment=None, parent=None):
+        """Method for package command handling"""
+        global LIST_TEMPLATE
+        query = {'apiurl': info.apiurl}
+        pkg_comment_ctrl = PackageComment(project, package)
+        result = getattr(pkg_comment_ctrl, method)(comment, parent, **query)
+        if method == 'list':
+            formated_comments = _format_for_output(result)
+            if info.interactive:
+                cls.shell(renderer, info.shell_cls, formated_comments,
+                          pkg_comment_ctrl, info)
+            renderer.render(LIST_TEMPLATE, comments=formated_comments)
+        else:
+            renderer.render(CREATE_TEMPLATE, status=result)
+
+    @classmethod
+    def project_comment(cls, renderer, project, method, info, comment=None,
+                        parent=None):
+        """Method for project command handling"""
+        global LIST_TEMPLATE
+        query = {'apiurl': info.apiurl}
+        proj_comment_ctrl = ProjectComment(project)
+        result = getattr(proj_comment_ctrl, method)(comment, parent,  **query)
+        if method == 'list':
+            formated_comments = _format_for_output(result)
+            if info.interactive:
+                cls.shell(renderer, info.shell_cls, formated_comments,
+                          proj_comment_ctrl, info)
+            renderer.render(LIST_TEMPLATE, comments=formated_comments)
+        else:
+            renderer.render(CREATE_TEMPLATE, status=result)
+
+    @classmethod
+    def request_comment(cls, renderer, request, method, info, comment=None,
+                        parent=None):
+        """Method for request command handling"""
+        global LIST_TEMPLATE
+        query = {'apiurl': info.apiurl}
+        req_comment_ctrl = RequestComment(request)
+        result = getattr(req_comment_ctrl, method)(comment, parent, **query)
+        if method == 'list':
+            formated_comments = _format_for_output(result)
+            if info.interactive:
+                cls.shell(renderer, info.shell_cls, formated_comments,
+                          req_comment_ctrl, info)
+            renderer.render(LIST_TEMPLATE, comments=formated_comments)
+        else:
+            renderer.render(CREATE_TEMPLATE, status=result)
+
+    @classmethod
+    def delete_comment(cls, renderer, comment_id, info):
+        """Method for comment deletion"""
+        query = {'apiurl': info.apiurl}
+        del_comment_ctrl = DeleteComment(comment_id)
+        result = del_comment_ctrl.delete(comment_id, **query)
+        renderer.render(CREATE_TEMPLATE, status=result)
+
+    @classmethod
+    def shell(cls, renderer, shell_cls, comments, cmt_controller, info):
+        """Interactive shell method"""
+        sh = shell_cls(renderer)
+        sh.run(comments, cmt_controller, info.apiurl)
+
+
+class AbstractCommentShell(AbstractShell):
+    """Represents an abstract comment shell."""
+
+    def __init__(self, *args, **kwargs):
+        """Constructs a new AbstractCommentShell object.
+
+        *args and **kwargs are passed to the base class'
+        __init__ method.
+
+        """
+        super(AbstractCommentShell, self).__init__(*args, **kwargs)
+        self._comment = None
+
+    def _augment_info(self, info):
+        super(AbstractCommentShell, self)._augment_info(info)
+        info.set('comment', self._comment)
+        info.set('cid', self._cid)
+        info.set('cmt_controller', self._cmt_controller)
+        info.set('apiurl', self._apiurl)
+
+    def run(self, comments, cmt_controller, apiurl):
+        """Run the shell.
+
+        comments is the ordered comments dict
+
+        """
+        self._cmt_controller = cmt_controller
+        self._apiurl = apiurl
+        self.clear()
+        for cid, comment in comments.items():
+            self._comment = comment
+            self._cid = cid
+            self.render(SHELL_TEMPLATE, cid=self._cid, com=self._comment)
+            next_req = False
+            while not next_req:
+                try:
+                    inp = self.prompt()
+                    next_req = self._execute(inp)
+                except SystemExit:
+                    # argparse automatically exits when the
+                    # help is requested
+                    pass
+                except ShellSyntaxError as e:
+                    self._renderer.render_text(str(e))
+                except KeyboardInterrupt as e:
+                    msg = "Press to ctrl-D to exit"
+                    self._renderer.render_text(msg)
+                except HTTPError as e:
+                    msg = "Error %s: %s" % (e.code, e.url)
+                    self._renderer.render_text(msg)
+            self.clear()
+
+
+class CommentShellController(CommentController):
+
+    def __init__(self):
+        self.stats = {}
+
+    def reply(self, shell, comment, cid, info, reply_text):
+        """Reply to a comment"""
+        query = {'apiurl': info.apiurl}
+        cmt_controller = info.cmt_controller
+        results = cmt_controller.create(reply_text, cid, **query)
+        for result in results:
+            print result
+
+    def create(self, shell, comment, info, create_text):
+        """Create a new comment"""
+        query = {'apiurl': info.apiurl}
+        cmt_controller = info.cmt_controller
+        results = cmt_controller.create(create_text, None, **query)
+        for result in results:
+            print result
+
+    def delete(self, shell, cid, info):
+        """Delete comment"""
+        query = {'apiurl': info.apiurl}
+        cmt_controller = info.cmt_controller
+        results = cmt_controller.delete(cid, **query)
+        for result in results:
+            print result
+
+    def next(self):
+        """Skips the current request."""
+        return True
+
+
+def _format_for_output(result):
+    f_comments = collections.OrderedDict()
+    level = 0
+    """Order comments and write to an ordered dict"""
+    comments = [(c, 0) for c in result.xpath('./comment[not(@parent)]')]
+    while comments:
+        comment, level = comments.pop(0)
+        xpb = XPathBuilder(context_item=True)
+        xp = xpb.comment[xpb.attr('parent') == comment.get('id')]
+        children = result.xpath(xp.tostring())
+        f_comments[comment.get('id')] = {'who': comment.get('who'),
+                                         'when': comment.get('when'),
+                                         'comment': comment,
+                                         'level': level
+                                         }
+        for child in children:
+            comments[:0] = [(child, level + 1)]
+    return f_comments

--- a/osc2/cli/comment/comment_create.jinja2
+++ b/osc2/cli/comment/comment_create.jinja2
@@ -1,0 +1,3 @@
+{% for value in status -%}
+    {{ value }}
+{% endfor %}

--- a/osc2/cli/comment/comment_list.jinja2
+++ b/osc2/cli/comment/comment_list.jinja2
@@ -1,0 +1,12 @@
+{% for cid, com in comments.items() %}
+      {%- if (com.get('level') == 0) %}
+          {{- '%s' | format( '+' * 60) }}
+      {%- endif %}
+      {{ '%s (%s) from %s at %s:' | format( ' ' * com.get('level'),
+                                            cid,
+                                            com.get('who'),
+                                            com.get('when'))
+                                            }}
+      {{ '%s %s' | format(' ' * com.get('level'), com.get('comment')) }}
+      {% if true %} {% endif %}
+{% endfor %}

--- a/osc2/cli/comment/comment_shell.jinja2
+++ b/osc2/cli/comment/comment_shell.jinja2
@@ -1,0 +1,10 @@
+{% if (com.get('level') == 0) %}
+{{ '%s' | format( '+' * 60) }}
+{% endif %}
+{{ '%s (%s) from %s at %s:' | format( ' ' * com.get('level'),
+                                            cid,
+                                            com.get('who'),
+                                            com.get('when'))
+                                            }}
+{{ '%s %s' | format(' ' * com.get('level'), com.get('comment')) }}
+{% if true %} {% endif %}

--- a/osc2/cli/comment/shell.py
+++ b/osc2/cli/comment/shell.py
@@ -1,0 +1,65 @@
+"""Defines commands for the interactive comments shell."""
+
+from osc2.cli.description import build_description, Option
+from osc2.cli.cli import call
+from osc2.cli.comment.comment import (CommentShellController,
+                                      AbstractCommentShell)
+
+ShellCommand = build_description('ShellCommand', {})
+
+
+class CommentShellUI(ShellCommand):
+    """Interactive comment shell."""
+    controller = CommentShellController()
+
+
+class ReplyComment(ShellCommand, CommentShellUI):
+    """Reply to comment.
+
+    Example:
+    reply COMMENT
+
+    """
+    cmd = 'reply'
+    args = 'reply_text'
+    func = call(CommentShellUI.controller.reply)
+
+
+class CreateComment(ShellCommand, CommentShellUI):
+    """Create comment.
+
+    Example:
+    create COMMENT
+
+    """
+    cmd = 'create'
+    args = 'create_text'
+    func = call(CommentShellUI.controller.create)
+
+
+class DeleteComment(ShellCommand, CommentShellUI):
+    """Delete comment.
+
+    Example:
+    delete
+
+    """
+    cmd = 'delete'
+    func = call(CommentShellUI.controller.delete)
+
+
+class CommentNext(ShellCommand, CommentShellUI):
+    """View next comment.
+
+    Example:
+    next
+
+    """
+    cmd = 'next'
+    func = call(CommentShellUI.controller.next)
+
+
+class CommentShell(AbstractCommentShell):
+    """Represents a comment shell."""
+    def _root_cmd_cls(self):
+        return CommentShellUI

--- a/osc2/cli/comment/ui.py
+++ b/osc2/cli/comment/ui.py
@@ -1,0 +1,136 @@
+"""Defines the comment command."""
+
+from osc2.cli.cli import OscCommand, call
+from osc2.cli.description import CommandDescription, Option
+from osc2.cli.comment.comment import CommentController
+from osc2.cli.comment.shell import CommentShell
+
+
+class Comment(CommandDescription, OscCommand):
+    """Show, create and delete comments."""
+    cmd = 'comment'
+
+
+class CommentList(CommandDescription, Comment):
+    """List comments."""
+    cmd = 'list'
+
+
+class PackageCommentList(CommandDescription, CommentList):
+    """List package comments.
+
+    List all comments available for the package
+
+    Example:
+    osc2 comment list package api://project/package
+    """
+    cmd = 'package'
+    args = 'api://project/package'
+    func = call(CommentController.package_comment)
+    func_defaults = {'method': 'list', 'shell_cls': CommentShell}
+    opt_interactive = Option('i', 'interactive',
+                             'start an interactive comment shell',
+                             action='store_true')
+
+
+class ProjectCommentList(CommandDescription, CommentList):
+    """"List project comments.
+
+    List all comments available for the project
+
+    Example:
+    osc2 comment list project api://project
+    """
+    cmd = 'project'
+    args = 'api://project'
+    func = call(CommentController.project_comment)
+    func_defaults = {'method': 'list', 'shell_cls': CommentShell}
+    opt_interactive = Option('i', 'interactive',
+                             'start an interactive comment shell',
+                             action='store_true')
+
+
+class RequestCommentList(CommandDescription, CommentList):
+    """"List request comments.
+
+    List all comments available for the request
+
+    Example:
+    osc2 comment list request api://reqid
+    """
+    cmd = 'request'
+    args = 'api://request'
+    func = call(CommentController.request_comment)
+    func_defaults = {'method': 'list'}
+    func_defaults = {'method': 'list', 'shell_cls': CommentShell}
+    opt_interactive = Option('i', 'interactive',
+                             'start an interactive comment shell',
+                             action='store_true')
+
+
+class CommentCreate(CommandDescription, Comment):
+    """Create comment."""
+    cmd = 'create'
+
+
+class CreateOptions(object):
+    """Options valid for all subclasses"""
+    opt_comment = Option('c', 'comment', 'specify a comment', required=True)
+    opt_parent = Option('p', 'parent', 'specify a comment to reply to')
+    func_defaults = {'method': 'create'}
+
+
+class PackageCommentCreate(CreateOptions, CommandDescription, CommentCreate):
+    """Create comment for the package
+
+    If no parent is given it is a top level comment.
+
+    Example:
+    osc2 comment create package api://project/package -c comment
+              -p parent_id
+    """
+    cmd = 'package'
+    args = 'api://project/package'
+    func = call(CommentController.package_comment)
+
+
+class ProjectCommentCreate(CreateOptions, CommandDescription, CommentCreate):
+    """Create comment for the project
+
+    If no parent is given it is a top level comment.
+
+    Example:
+    osc2 comment create project api://project -c comment
+              -p parent_id
+    """
+    cmd = 'project'
+    args = 'api://project'
+    func = call(CommentController.project_comment)
+
+
+class RequestCommentCreate(CreateOptions, CommandDescription, CommentCreate):
+    """Create comment for the request
+
+    If no parent is given it is a top level comment.
+
+    Example:
+    osc2 comment create request api://reqid -c comment
+              -p parent_id
+    """
+    cmd = 'request'
+    args = 'api://request'
+    func = call(CommentController.request_comment)
+
+
+class RequestCommentDelete(CommandDescription, Comment):
+    """Delete comment.
+
+    Deletes comment with the given comment id.
+
+    Example:
+    osc2 comment delete api://comment
+
+    """
+    cmd = 'delete'
+    args = 'api://comment_id'
+    func = call(CommentController.delete_comment)

--- a/osc2/comments.py
+++ b/osc2/comments.py
@@ -1,0 +1,72 @@
+"""Provides classes to access the comments route"""
+
+from osc2.core import Osc
+from osc2.util.xml import OscElement, fromstring
+from lxml import etree
+
+
+class CommentsElement(OscElement):
+    def __iter__(self):
+        return self.iterfind('comment')
+
+
+class Status(OscElement):
+    def __iter__(self):
+        return self.iterfind('summary')
+
+
+class Comments(object):
+    def __init__(self, *args):
+        self._path = self._get_path(*args)
+
+    def _get_path(self, *args):
+        """Build the path for the api"""
+        path_base = 'comments/'
+        return path_base + '/'.join(args)
+
+    def list(self, gbg1, gbg2, **kwargs):
+        """Returns the comments as xml"""
+        request = Osc.get_osc().get_reqobj()
+        f = request.get(self._path, **kwargs)
+        comments = fromstring(f.read(), comments=CommentsElement)
+        return comments
+
+    def create(self, comment, parent, **kwargs):
+        """Creates the comment and returns the status"""
+        if parent is not None:
+            kwargs['parent_id'] = parent
+        request = Osc.get_osc().get_reqobj()
+        f = request.post(self._path, data=str(comment), **kwargs)
+        result = fromstring(f.read(), status=Status)
+        return result
+
+    def delete(self, comment_id, **kwargs):
+        """Deletes the comment and returns the status"""
+        request = Osc.get_osc().get_reqobj()
+        path = 'comment/' + str(comment_id)
+        f = request.delete(path, **kwargs)
+        result = fromstring(f.read(), status=Status)
+        return result
+
+
+class PackageComment(Comments):
+    """Represents a package comment"""
+    def __init__(self, project, package):
+        super(PackageComment, self).__init__('package', project, package)
+
+
+class ProjectComment(Comments):
+    """Represents a project comment"""
+    def __init__(self, project):
+        super(ProjectComment, self).__init__('project', project)
+
+
+class RequestComment(Comments):
+    """Represents a request comment"""
+    def __init__(self, request):
+        super(RequestComment, self).__init__('request', request)
+
+
+class DeleteComment(Comments):
+    def __init__(self):
+        """Represents a delete comment"""

--- a/test/suite.py
+++ b/test/suite.py
@@ -9,6 +9,7 @@ from test import test_oscargs
 from test import test_builder
 from test import test_fetch
 from test import test_search
+from test import test_comments
 from test.wc import test_util
 from test.wc import test_project
 from test.wc import test_package
@@ -41,6 +42,7 @@ def additional_tests():
     suite.addTests(test_io.suite())
     suite.addTests(test_delegation.suite())
     suite.addTests(test_shell.suite())
+    suite.addTests(test_comments.suite())
     return suite
 
 if __name__ == '__main__':

--- a/test/test_comments.py
+++ b/test/test_comments.py
@@ -1,0 +1,71 @@
+import unittest
+
+from osc2.comments import PackageComment, ProjectComment, RequestComment
+from test.osctest import OscTest
+from test.httptest import GET, POST
+
+
+def suite():
+    return unittest.makeSuite(TestComments)
+
+
+class TestComments(OscTest):
+    def __init__(self, *args, **kwargs):
+        kwargs['fixtures_dir'] = 'test_comments_fixtures'
+        super(TestComments, self).__init__(*args, **kwargs)
+
+    @POST('http://localhost/comments/package/openSUSE%3AFactory/osc',
+          exp='This is a test', text='<OK/>')
+    def test_create_package_comment(self):
+        """test create package comment"""
+        pkg_comment_ctrl = PackageComment('openSUSE:Factory', 'osc')
+        pcmt = pkg_comment_ctrl.create('This is a test', None)
+
+    @POST('http://localhost/comments/project/openSUSE%3AFactory',
+          exp='This is a test', text='<OK/>')
+    def test_create_project_comment(self):
+        """test create project comment"""
+        proj_comment_ctrl = ProjectComment('openSUSE:Factory')
+        projcmt = proj_comment_ctrl.create('This is a test', None)
+
+    @POST('http://localhost/comments/request/1', exp='This is a test',
+          text='<OK/>')
+    def test_create_request_comment(self):
+        """test create request comment"""
+        req_comment_ctrl = RequestComment('1')
+        rcmt = req_comment_ctrl.create('This is a test', None)
+
+    @GET('http://localhost/comments/package/openSUSE%3AFactory/osc',
+         file='pkg_comments.xml')
+    def test_list_package_comments(self):
+        """test list package comments"""
+        PackageComment.SCHEMA = self.fixture_file('pkg_comment.xsd')
+        pkg_comment_ctrl = PackageComment('openSUSE:Factory', 'osc')
+        pcmt = pkg_comment_ctrl.list(None, None)
+        self.assertEqual(pcmt.get('package'), 'osc')
+        self.assertEqual(pcmt.comment[0], 'P_Comment_1')
+        self.assertEqual(pcmt.comment[1], 'P_Comment_2')
+
+    @GET('http://localhost/comments/project/openSUSE%3AFactory',
+         file='proj_comments.xml')
+    def test_list_project_comments(self):
+        """test list package comments"""
+        ProjectComment.SCHEMA = self.fixture_file('proj_comment.xsd')
+        proj_comment_ctrl = ProjectComment('openSUSE:Factory')
+        projcmt = proj_comment_ctrl.list(None, None)
+        self.assertEqual(projcmt.get('project'), 'openSUSE:Factory')
+        self.assertEqual(projcmt.comment[0], 'Proj_Comment_1')
+        self.assertEqual(projcmt.comment[1], 'Proj_Comment_2')
+
+    @GET('http://localhost/comments/request/1', file='req_comments.xml')
+    def test_list_request_comments(self):
+        """test list request comments"""
+        RequestComment.SCHEMA = self.fixture_file('req_comment.xsd')
+        req_comment_ctrl = RequestComment('1')
+        rcmt = req_comment_ctrl.list(None, None)
+        self.assertEqual(rcmt.get('request'), '1')
+        self.assertEqual(rcmt.comment[0], 'R_Comment_1')
+        self.assertEqual(rcmt.comment[1], 'R_Comment_2')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_comments_fixtures/pkg_comments.xml
+++ b/test/test_comments_fixtures/pkg_comments.xml
@@ -1,0 +1,4 @@
+<comments project="openSUSE:Factory" package="osc">
+  <comment who="Admin" when="2017-02-21 12:39:25 UTC" id="3">P_Comment_1</comment>
+  <comment who="Admin" when="2017-02-21 12:39:30 UTC" id="4">P_Comment_2</comment>
+</comments>

--- a/test/test_comments_fixtures/pkg_comments.xsd
+++ b/test/test_comments_fixtures/pkg_comments.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  elementFormDefault="qualified">
+
+  <xs:element name="comments">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="comment" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="project" type="xs:string"/>
+      <xs:attribute name="package" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="comment">
+    <xs:complexType>
+      <xs:attribute name="who" type="xs:string"/>
+      <xs:attribute name="when" type="xs:string"/>
+      <xs:attribute name="id" type="xs:string"/>
+      <xs:attribute name="parent" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/test/test_comments_fixtures/proj_comments.xml
+++ b/test/test_comments_fixtures/proj_comments.xml
@@ -1,0 +1,4 @@
+<comments project="openSUSE:Factory">
+  <comment who="Admin" when="2017-02-21 12:39:25 UTC" id="3">Proj_Comment_1</comment>
+  <comment who="Admin" when="2017-02-21 12:39:30 UTC" id="4">Proj_Comment_2</comment>
+</comments>

--- a/test/test_comments_fixtures/proj_comments.xsd
+++ b/test/test_comments_fixtures/proj_comments.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  elementFormDefault="qualified">
+
+  <xs:element name="comments">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="comment" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="project" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="comment">
+    <xs:complexType>
+      <xs:attribute name="who" type="xs:string"/>
+      <xs:attribute name="when" type="xs:string"/>
+      <xs:attribute name="id" type="xs:string"/>
+      <xs:attribute name="parent" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/test/test_comments_fixtures/req_comments.xml
+++ b/test/test_comments_fixtures/req_comments.xml
@@ -1,0 +1,4 @@
+<comments project="openSUSE:Factory" request="1">
+  <comment who="Admin" when="2017-02-21 12:39:25 UTC" id="3">R_Comment_1</comment>
+  <comment who="Admin" when="2017-02-21 12:39:30 UTC" id="4">R_Comment_2</comment>
+</comments>

--- a/test/test_comments_fixtures/req_comments.xsd
+++ b/test/test_comments_fixtures/req_comments.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  elementFormDefault="qualified">
+
+  <xs:element name="comments">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="comment" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="request" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="comment">
+    <xs:complexType>
+      <xs:attribute name="who" type="xs:string"/>
+      <xs:attribute name="when" type="xs:string"/>
+      <xs:attribute name="id" type="xs:string"/>
+      <xs:attribute name="parent" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
### List and create comments

adding comments command to osc2. Comments can be listed, created, replied to and deleted.

Base Syntax:
```
osc2 comments <action> package api://project/package [-c] [-p]
osc2 comments <action> project api://project [-c] [-p]
osc2 comments <action> request api://reqeust[-c] [-p]
```
where action can be `list` or `create`
-c defines the comment text.
If -p is given the comment is a reply to an existing comment with the given id

The list command has an interactive mode:
```osc2 comment list package -i api://project/package```

In this mode you can go through the comments and can:
* n (next comment)
* reply (reply to comment)
* create (create new comment)
* delete (delete comment)

### Delete comments

You can delete a comment:

```osc2 comment delete api://comment_id```